### PR TITLE
Allow color families by descendants (WIP)

### DIFF
--- a/diagramitem.cpp
+++ b/diagramitem.cpp
@@ -74,7 +74,8 @@ DiagramItem::DiagramItem(DiagramType diagramType, QMenu *contextMenu,
       m_spouse(nullptr),
       m_movedBySpouse(false),
       m_marriageItem(nullptr),
-      m_thumbnail(nullptr)
+      m_thumbnail(nullptr),
+      m_familyColor(Qt::black)
 {
     myDiagramType = diagramType;
     myContextMenu = contextMenu;
@@ -411,6 +412,25 @@ void DiagramItem::updateThumbnail()
 
     // Set visibility.
     m_thumbnail->setVisible(m_showThumbnail);
+}
+
+QColor DiagramItem::getFamilyColor() const
+{
+    return m_familyColor;
+}
+
+void DiagramItem::setFamilyColor(const QColor &familyColor)
+{
+    // Set field.
+    m_familyColor = familyColor;
+
+    // Set border color.
+    setPen(QPen(familyColor, 1));
+
+    // Update children colors.
+    for (auto child: getChildren()) {
+        child->setFamilyColor(familyColor);
+    }
 }
 
 DiagramItem::SpousePosition DiagramItem::getSpousePosition() const

--- a/diagramitem.h
+++ b/diagramitem.h
@@ -164,6 +164,9 @@ public:
     QColor getTextColor() const;
     void setTextColor(const QColor &color);
 
+    QColor getFamilyColor() const;
+    void setFamilyColor(const QColor &familyColor);
+
 protected:
     void contextMenuEvent(QGraphicsSceneContextMenuEvent *event) override;
     QVariant itemChange(GraphicsItemChange change, const QVariant &value) override;
@@ -202,6 +205,8 @@ private:
     QString m_firstName;
     QString m_lastName;
     QString m_gender;
+
+    QColor m_familyColor;
 };
 
 #endif // DIAGRAMITEM_H

--- a/gui/dialogpersondetails.cpp
+++ b/gui/dialogpersondetails.cpp
@@ -8,6 +8,7 @@
 #include "undo/editpersondetailsundo.h"
 #include "undo/undomanager.h"
 
+#include <QColorDialog>
 #include <QDebug>
 #include <QFileDialog>
 #include <QStandardPaths>
@@ -71,6 +72,10 @@ void DialogPersonDetails::setItem(DiagramItem *item)
     {
         addPhoto(photo);
     }
+
+    // Family color.
+    m_familyColor = item->getFamilyColor();
+    updateFamilyColorButtonIcon();
 
     // Update window title.
     setWindowTitle(QString("Person Details - ") + item->name());
@@ -161,6 +166,9 @@ void DialogPersonDetails::save()
         QStringList photos = getPhotoListFromGui();
         m_item->setPhotos(photos);
 
+        // Family color.
+        m_item->setFamilyColor(m_familyColor);
+
         undo->setAfterState(m_item);
         UndoManager::add(undo);
     }
@@ -202,6 +210,15 @@ void DialogPersonDetails::viewPhoto(int index)
 QString DialogPersonDetails::getPhotosFolder() const
 {
     return FileUtils::getPhotosFolderFor(m_xmlFile);
+}
+
+void DialogPersonDetails::updateFamilyColorButtonIcon()
+{
+    QPixmap iconPixmap(12, 12);
+    iconPixmap.fill(m_familyColor);
+    QIcon icon(iconPixmap);
+    ui->pushButtonFamilyColor->setIcon(icon);
+    ui->pushButtonFamilyColor->setText("");
 }
 
 //void DialogPersonDetails::setTextGrayedOut(QWidget *widget, bool grayedOut)
@@ -334,4 +351,14 @@ void DialogPersonDetails::on_listWidgetPhotos_itemDoubleClicked(QListWidgetItem 
 void DialogPersonDetails::on_listWidgetPhotos_activated(const QModelIndex &index)
 {
     viewPhoto(index.row());
+}
+
+void DialogPersonDetails::on_pushButtonFamilyColor_clicked()
+{
+    QColor newColor = QColorDialog::getColor(m_familyColor, this, "Select Family Color");
+    if (newColor.isValid())
+    {
+        m_familyColor = newColor;
+        updateFamilyColorButtonIcon();
+    }
 }

--- a/gui/dialogpersondetails.h
+++ b/gui/dialogpersondetails.h
@@ -47,6 +47,8 @@ private slots:
 
     void on_listWidgetPhotos_activated(const QModelIndex &index);
 
+    void on_pushButtonFamilyColor_clicked();
+
 private:
     void save();
     void addPhoto(const QString &fileName);
@@ -54,6 +56,7 @@ private:
     void viewPhoto(int index);
 //    void viewPhoto(const QString &fileName);
     QString getPhotosFolder() const;
+    void updateFamilyColorButtonIcon();
 
     Ui::DialogPersonDetails *ui;
     DiagramItem *m_item;
@@ -62,6 +65,8 @@ private:
     QString m_xmlFile;
     QString m_lastPhotoFolder;
     QStringList getPhotoListFromGui();
+
+    QColor m_familyColor;
 };
 
 #endif // DIALOGPERSONDETAILS_H

--- a/gui/dialogpersondetails.ui
+++ b/gui/dialogpersondetails.ui
@@ -17,7 +17,7 @@
    <item>
     <widget class="QTabWidget" name="tabWidgetMain">
      <property name="currentIndex">
-      <number>0</number>
+      <number>3</number>
      </property>
      <widget class="QWidget" name="tabDetails">
       <attribute name="title">
@@ -42,7 +42,7 @@
           <item row="2" column="0">
            <widget class="QLabel" name="labelName">
             <property name="text">
-             <string>Display name:</string>
+             <string>Display &amp;name:</string>
             </property>
             <property name="buddy">
              <cstring>lineEditName</cstring>
@@ -328,6 +328,33 @@
            </widget>
           </item>
          </layout>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="tabColors">
+      <attribute name="title">
+       <string>Colors</string>
+      </attribute>
+      <layout class="QFormLayout" name="formLayout_2">
+       <property name="fieldGrowthPolicy">
+        <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+       </property>
+       <property name="formAlignment">
+        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+       </property>
+       <item row="0" column="0">
+        <widget class="QLabel" name="labelFamilyColor">
+         <property name="text">
+          <string>Border color for family (descendents):</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="QPushButton" name="pushButtonFamilyColor">
+         <property name="text">
+          <string>...</string>
+         </property>
         </widget>
        </item>
       </layout>


### PR DESCRIPTION
This is a possible fix for issue #1.

To use it:

1. Right click on the person and select "Details..."
1. Go to the "Colors" tab.
1. Click the color button.
1. Select a new color.
1. Click "Save".
1. The person and their descendants will have the chosen border color.

**Current Issues**

* The chosen color is applied, regardless of whether you changed it or not.
* It is difficult to see the color change on the selected person, since it is highlighted with a dotted black line.
* If you add/create a new descendant, the border color is not automatically applied to them.
* If you remove a person from the descendant line, the border color remains on them.
* The border color is not applied to children of the spouse.
* The setting is not saved in XML.