### PR TITLE
Fix preference window size automatically

### DIFF
--- a/gui/preferenceswindow.cpp
+++ b/gui/preferenceswindow.cpp
@@ -19,6 +19,9 @@ PreferencesWindow::PreferencesWindow(QWidget *parent) :
         QPoint offset(halfSize.width(), halfSize.height());
         move(geometry.center() - offset);
     }
+
+    // Use the minimum size.
+    adjustSize();
 }
 
 PreferencesWindow::~PreferencesWindow()


### PR DESCRIPTION
This removes the empty space in the preference dialog on Windows.