### PR TITLE
Avoid "jump" when finished editing name after placing person

### DIFF
--- a/diagramtextitem.cpp
+++ b/diagramtextitem.cpp
@@ -132,5 +132,13 @@ void DiagramTextItem::keyPressEvent(QKeyEvent *event)
     }
     else {
         QGraphicsTextItem::keyPressEvent(event);
+
+        // Align to center of parent if currently editing.
+        if (textInteractionFlags() == Qt::TextEditorInteraction) {
+            auto parentRect = parentItem();
+            if (parentRect) {
+                setPos(parentRect->boundingRect().center().x() - boundingRect().width() / 2, y());
+            }
+        }
     }
 }


### PR DESCRIPTION
After adding a person to the diagram, you can edit their name directly. However, it "jumps" into place at the center of the box after you finish typing. This PR fixes that problem by always keeping it centered while you type.