### PR TITLE
Disallow marrying a child

### DIFF
--- a/diagramitem.cpp
+++ b/diagramitem.cpp
@@ -223,6 +223,14 @@ void DiagramItem::marryTo(DiagramItem *spouse)
     m_spouse->updateArrowPositions();
 }
 
+bool DiagramItem::canMarry(DiagramItem *potentialSpouse) const
+{
+    return  !isMarried() &&
+            !potentialSpouse->isMarried()  &&
+            !getChildren().contains(potentialSpouse) &&
+            !getParents().contains(potentialSpouse);
+}
+
 QUuid DiagramItem::id() const
 {
     return m_id;

--- a/diagramitem.h
+++ b/diagramitem.h
@@ -95,6 +95,7 @@ public:
     void setName(QString value);
     void setHighlighted(bool value);
     void marryTo(DiagramItem *spouse);
+    bool canMarry(DiagramItem *potentialSpouse) const;
     QUuid id() const;
     void setId(const QUuid& value);
     DiagramTextItem *textItem();

--- a/diagramscene.cpp
+++ b/diagramscene.cpp
@@ -880,42 +880,37 @@ void DiagramScene::mouseMoveEvent(QGraphicsSceneMouseEvent *mouseEvent)
         }
 
         // Check for marriage.
-        bool checkForMarriage = false;
         if (draggedItem && draggedItem->type() == DiagramItem::Type)
         {
             auto draggedDiagramItem = qgraphicsitem_cast<DiagramItem *>(draggedItem);
-            if (!draggedDiagramItem->isMarried()) {
-                checkForMarriage = true;
-            }
-        }
 
-        if (checkForMarriage) {
-//            auto pos = mouseEvent->scenePos();
-//            QList<QGraphicsItem *> list = items(pos);
-            QList<QGraphicsItem *> list = draggedItem->collidingItems();
+            if (!draggedDiagramItem->isMarried())
+            {
+                QList<QGraphicsItem *> list = draggedItem->collidingItems();
 
-            bool found = false;
-            for (auto item: list) {
-                if (item != draggedItem) {
-                    if (item->type() == DiagramItem::Type) {
+                bool found = false;
+                for (auto item: list)
+                {
+                    if (item != draggedItem && item->type() == DiagramItem::Type)
+                    {
                         auto diagramItem = qgraphicsitem_cast<DiagramItem *>(item);
-                        if (!diagramItem->isMarried()) {
+                        if (draggedDiagramItem->canMarry(diagramItem))
+                        {
                             found = true;
                             highlight(diagramItem);
                             break;
                         }
                     }
                 }
-            }
 
-            // Nothing found, so unlighlight all.
-            if (!found) {
-                unHighlightAll();
+                // Nothing found, so unlighlight all.
+                if (!found) {
+                    unHighlightAll();
+                }
             }
         }
     }
 }
-//! [10]
 
 void DiagramScene::mouseReleaseEvent(QGraphicsSceneMouseEvent *mouseEvent)
 {


### PR DESCRIPTION
# Description

This makes it so that a person cannot marry their child or parent. They will not be highlighted for potential marriage when dragged over.

# After creating the PR

- [x] Enable "Allow edits from maintainers".

# Before merging the PR

- [ ] Add unit tests that cover any added or changed code. (Seems too difficult.)
- [ ] Update the help file. (Not required.)
